### PR TITLE
Change T4Scaffolding.Core.VS2017 dep to >= 1.0.1

### DIFF
--- a/T4Scaffolding/T4Scaffolding.nuspec
+++ b/T4Scaffolding/T4Scaffolding.nuspec
@@ -8,7 +8,7 @@
     <description>A fast and customizable way to build parts of your .NET application via templates</description>
     <summary>A fast and customizable way to build parts of your .NET application via templates</summary>
     <dependencies>
-      <dependency id="T4Scaffolding.Core.VS2017" version="1.0.0" />
+      <dependency id="T4Scaffolding.Core.VS2017" version="1.0.1" />
       <dependency id="EntityFramework" version="4.1.10311.0" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
T4Scaffolding.Core.VS2017 1.0.0 has a bug that has been fixed in 1.0.1, but this dependency has not been updated, so by default the older package is still installed. Updating this dependency solves the issue. Solves Issue #7.